### PR TITLE
ДЗ №3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'draper', '~> 4.0', '>= 4.0.4'
 # Пагинация
 gem 'kaminari-mongoid'
 
+# Брокер сообщений
+gem 'karafka', '~> 2.0'
+
 group :development, :test do
   gem 'bundler-audit'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,19 @@ GEM
     kaminari-mongoid (1.0.2)
       kaminari-core (~> 1.0)
       mongoid
+    karafka (2.4.17)
+      base64 (~> 0.2)
+      karafka-core (>= 2.4.4, < 2.5.0)
+      karafka-rdkafka (>= 0.17.2)
+      waterdrop (>= 2.7.3, < 3.0.0)
+      zeitwerk (~> 2.3)
+    karafka-core (2.4.9)
+      karafka-rdkafka (>= 0.17.6, < 0.19.0)
+      logger (>= 1.6.0)
+    karafka-rdkafka (0.18.1)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
     language_server-protocol (3.17.0.3)
     logger (1.6.0)
     loofah (2.23.1)
@@ -445,6 +458,10 @@ GEM
     useragent (0.16.10)
     warden (1.2.9)
       rack (>= 2.0.9)
+    waterdrop (2.8.2)
+      karafka-core (>= 2.4.3, < 3.0.0)
+      karafka-rdkafka (>= 0.17.5)
+      zeitwerk (~> 2.3)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -488,6 +505,7 @@ DEPENDENCIES
   fasterer
   ffaker
   kaminari-mongoid
+  karafka (~> 2.0)
   mongoid (~> 9.0, >= 9.0.6)
   parallel
   pg

--- a/app/consumers/application_consumer.rb
+++ b/app/consumers/application_consumer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Application consumer from which all Karafka consumers should inherit
+# You can rename it if it would conflict with your current code base (in case you're integrating
+# Karafka with other frameworks)
+class ApplicationConsumer < Karafka::BaseConsumer
+end

--- a/app/consumers/likes_consumer.rb
+++ b/app/consumers/likes_consumer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Example consumer that prints messages payloads
+class LikesConsumer < ApplicationConsumer
+  def consume
+    messages.each { |message| process_message(message) }
+  end
+
+  private
+
+  def process_message(message)
+    payload = message.payload.symbolize_keys
+    Rails.logger.info("topic: #{topic.name}, client: #{[client.id, client.name].join('_')}, payload: #{payload}")
+    LikesService.call(
+      action: payload[:action].to_sym,
+      params: payload[:params].transform_keys(&:to_sym)
+    )
+  end
+end

--- a/app/lib/likes/create_like.rb
+++ b/app/lib/likes/create_like.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Likes::CreateLike
+  include Callable
+  extend Dry::Initializer
+
+  param :book
+
+  def call
+    book.inc(likes_count: 1)
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -7,6 +7,7 @@ class Book
   field :filename, type: String
   field :ext, type: String
   field :folder_id, type: String
+  field :likes_count, type: Integer, default: 0
 
   def authors
     Author.joins(:books_authors).where(books_authors: { book_id: id })

--- a/app/serializers/book_resource.rb
+++ b/app/serializers/book_resource.rb
@@ -3,7 +3,7 @@
 class BookResource
   include Alba::Resource
 
-  attributes :id, :title, :file_path, :published_at
+  attributes :id, :title, :file_path, :likes_count, :published_at
 
   many :authors
   many :genres

--- a/app/services/likes_service.rb
+++ b/app/services/likes_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class LikesService
+  include Callable
+  extend Dry::Initializer
+
+  option :action, type: Dry::Types['strict.symbol']
+  option :params, type: Dry::Types['strict.hash']
+
+  def call
+    case action
+    when :like
+      Likes::CreateLike.call(
+        Book.find(params[:id])
+      )
+    end
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,11 @@
+x-base-service: &base-service
+  build:
+    context: .
+    dockerfile: Dockerfile
+  image: library
+  stdin_open: true
+  tty: true
+
 services:
   db:
     image: postgres:17
@@ -18,12 +26,8 @@ services:
       - mongodb:/data/db
 
   web:
-    tty: true
-    stdin_open: true
-    image: library
+    <<: *base-service
     container_name: library
-    build:
-      context: .
     env_file:
       ".env"
     command: >
@@ -35,7 +39,7 @@ services:
     networks:
       - default
     ports:
-      - "8080:3000"
+      - "3000:3000"
     depends_on:
       - db
       - mongo
@@ -46,6 +50,62 @@ services:
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: 'postgres'
       MONGO_URI: ${MONGO_URI:-mongodb://admin:Z76pPAcLvct@mongo:27017}
+
+  redpanda:
+    image: redpandadata/redpanda
+    command:
+      - redpanda start
+      - --smp 1
+      - --overprovisioned
+      - --node-id 0
+      - --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr PLAINTEXT://redpanda:29092,OUTSIDE://redpanda:9092
+      - --pandaproxy-addr 0.0.0.0:8082
+      - --advertise-pandaproxy-addr redpanda:8082
+    ports:
+      - 8081:8081
+      - 8082:8082
+      - 9092:9092
+      - 29092:29092
+
+  console:
+    image: docker.redpanda.com/redpandadata/console
+    restart: on-failure
+    entrypoint: /bin/sh
+    command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"
+    environment:
+      CONFIG_FILEPATH: /tmp/config.yml
+      CONSOLE_CONFIG_FILE: |
+        kafka:
+          brokers: ["redpanda:29092"]
+          schemaRegistry:
+            enabled: true
+            urls: ["http://redpanda:8081"]
+        connect:
+          enabled: true
+          clusters:
+            - name: datagen
+              url: http://connect:8083
+    ports:
+      - 8080:8080
+    depends_on:
+      - redpanda
+
+  karafka:
+    <<: *base-service
+    command: bundle exec karafka server
+    env_file:
+      ".env"
+    environment:
+      KARAFKA_BOOT_FILE: '/app/karafka.rb'
+      APP_HOST: ${APP_HOST:-localhost}
+      KAFKATRY_DATABASE_PASSWORD: ${KAFKATRY_DATABASE_PASSWORD:-DYfrvXT4Cuf9AtjMsYA}
+      MONGO_URI: ${MONGO_URI:-mongodb://admin:Z76pPAcLvct@mongo:27017}
+    volumes:
+      - .:/app
+      - ~/.bash_history:/root/.bash_history
+      - ~/.irbrc:/root/.irbrc
+
 volumes:
   db:
   mongodb:

--- a/karafka.rb
+++ b/karafka.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class KarafkaApp < Karafka::App
+  setup do |config|
+    config.kafka = { 'bootstrap.servers': 'redpanda:9092' }
+    config.client_id = 'workshop_architecture'
+    # Recreate consumers with each batch. This will allow Rails code reload to work in the
+    # development mode. Otherwise Karafka process would not be aware of code changes
+    config.consumer_persistence = !Rails.env.development?
+  end
+
+  # Comment out this part if you are not using instrumentation and/or you are not
+  # interested in logging events for certain environments. Since instrumentation
+  # notifications add extra boilerplate, if you want to achieve max performance,
+  # listen to only what you really need for given environment.
+  Karafka.monitor.subscribe(Karafka::Instrumentation::LoggerListener.new)
+  # Karafka.monitor.subscribe(Karafka::Instrumentation::ProctitleListener.new)
+
+  # This logger prints the producer development info using the Karafka logger.
+  # It is similar to the consumer logger listener but producer oriented.
+  Karafka.producer.monitor.subscribe(
+    WaterDrop::Instrumentation::LoggerListener.new(Karafka.logger)
+  )
+
+  routes.draw do
+    # Uncomment this if you use Karafka with ActiveJob
+    # You need to define the topic per each queue name you use
+    # active_job_topic :default
+
+    topic :likes do
+      consumer LikesConsumer
+    end
+  end
+end

--- a/lib/tasks/like.rake
+++ b/lib/tasks/like.rake
@@ -1,0 +1,9 @@
+desc 'Ставим like'
+task like: :environment do
+  json_path = Rails.root.join('spec', 'fixtures', 'like.json').to_path
+  payload = JSON.parse(File.read(json_path)).to_json
+  Karafka.producer.produce_async(
+    topic: 'likes',
+    payload: payload
+  )
+end

--- a/spec/fixtures/like.json
+++ b/spec/fixtures/like.json
@@ -1,0 +1,11 @@
+{
+  "id": "ffffeade-4ee7-4525-a837-2b7af00f136f",
+  "from": "rake",
+  "action": "like",
+  "params": {
+    "id": "ffffeade-4ee7-4525-a837-2b7af00f136f",
+    "action": "like",
+    "folder": "f.fb2-440801-444899.zip",
+    "book": "440905"
+  }
+}


### PR DESCRIPTION
В docker-compose.yml добавьте Apache Kafka. Переработайте отправку событий в микросервисах через нее.

Добавьте дополнительно панель управления RedPanda для мониторинга за топиками Apache Kafka. В разработке можно опираться на приложение-пример docs/kafkatry-ruby из основного репозитория (внутри есть docker-compose c redpanda-панелью, которая позволит визуализировать топики) : https://github.com/thinknetica/workshop_architecture/tree/master/docs/kafkatry-ruby

```
1. Идеально, если при старте library при помощи гема karafka мы создаем топик скажем like_in
2. Создаем rake-задачу like, которую мы делали на третьем занятии, но отправляем json-сообщение в kafka-топик like_in при помощи гема bunny
3. В обработчике karafka принимаем сообщение (можно данные записать в rails-лог, но если создать модель like и положить запись туда - будет плюс)
```